### PR TITLE
Listen on network interfaces rather than localhost

### DIFF
--- a/cherrypy/_cpserver.py
+++ b/cherrypy/_cpserver.py
@@ -25,7 +25,7 @@ class Server(ServerAdapter):
     socket_port = 8080
     """The TCP port on which to listen for connections."""
     
-    _socket_host = '127.0.0.1'
+    _socket_host = '0.0.0.0'
     def _get_socket_host(self):
         return self._socket_host
     def _set_socket_host(self, value):


### PR DESCRIPTION
Hi, thank you for maintaining this again, I was very excited to see it had been picked up!

Can you please make the default behaviour to listen on the network interface rather than just on localhost as most people run LL,CP,SB etc... on another server / media centre.
