### PR TITLE
Changes to accommodate methods removed in Python 3.8

### DIFF
--- a/cherrypy/_cperror.py
+++ b/cherrypy/_cperror.py
@@ -115,8 +115,14 @@ Note that you have to explicitly set
 and not simply return an error message as a result.
 """
 
-from cgi import escape as _escape
 from sys import exc_info as _exc_info
+from sys import version_info as _version_info
+if _version_info <=(3,7):
+    from cgi import escape as _escape
+else:
+    from html import escape as _escape
+
+
 from traceback import format_exception as _format_exception
 from cherrypy._cpcompat import basestring, bytestr, iteritems, ntob
 from cherrypy._cpcompat import tonative, urljoin as _urljoin

--- a/lazylibrarian/common.py
+++ b/lazylibrarian/common.py
@@ -842,7 +842,7 @@ def reverse_readline(filename, buf_size=8192):
                 # if the previous chunk starts right from the beginning of line
                 # do not concact the segment to the last line of new chunk
                 # instead, yield the segment first
-                if buf[-1] is not '\n':
+                if buf[-1] != '\n':
                     lines[-1] += segment
                 else:
                     yield segment
@@ -871,7 +871,8 @@ def logHeader():
             header += '%s: %s\n' % (item.lower(), lazylibrarian.CONFIG[item])
     header += "Python version: %s\n" % sys.version.split('\n')
     # noinspection PyDeprecation
-    header += "Distribution: %s\n" % str(platform.dist())
+    if sys.version_info<=(3,7):
+        header += "Distribution: %s\n" % str(platform.dist())
     header += "System: %s\n" % str(platform.system())
     header += "Machine: %s\n" % str(platform.machine())
     header += "Platform: %s\n" % str(platform.platform())


### PR DESCRIPTION
Two older deprecated methods were removed in Python 3.8 and prevent startup.  One method is now implemented in the html module.

if _version_info <=(3,7):
    from cgi import escape as _escape
else:
    from html import escape as _escape

The other simply seems to be removed, so I made the line conditional with older versions.

I also fixed an "is not" expression with a literal which should be a != 